### PR TITLE
Added fixed MAC addrs to get IP again from DHCP.

### DIFF
--- a/deployment/helm/templates/aziot-edge-vm.yaml
+++ b/deployment/helm/templates/aziot-edge-vm.yaml
@@ -28,13 +28,20 @@ spec:
             serial: D23YZ9W6WA5DJ487
           - cdrom:
               bus: sata
-            name: cloudinitdisk        
+            name: cloudinitdisk
+          interfaces:
+          - masquerade: {}
+            macAddress: fe:7e:48:a0:7d:22
+            name: default         
         machine:
           type: q35
         resources:
           requests:
             # 4GB
             memory: 4096M
+      networks:
+      - name: default
+        pod: {}
       volumes:
       - dataVolume:
          name: {{ include "aziotedgevm.name" . }}-linux-dv


### PR DESCRIPTION
This PR resolves the issue where VM instance is unable to assign IP to the guest OS if VM's MAC address is changed, MAC address changes every time you restart the VM but guest OS's config still keeps the old MAC address (e.g. in Ubuntu 18.04 it's defined in  /etc/netplan/50-cloud-init.yaml). 
We have now fixed the MAC address for the VM to resolve this issue, this may also help with software licensing as MAC address is retained when VM is started again (IP will still change when you restart the VM instance).
A by-product of this was causing issue [#1](https://github.com/suneetnangia/kvedge/issues/1), this issue should now be fixed.
CC @veyalla 